### PR TITLE
Fix "attempt to concatenate local 'hl'" error

### DIFF
--- a/lua/luatab/init.lua
+++ b/lua/luatab/init.lua
@@ -49,7 +49,7 @@ local function tabDevicon(bufnr, isSelected)
         local fg = h.extract_highlight_colors(devhl, 'fg')
         local bg = h.extract_highlight_colors('TabLineSel', 'bg')
         local hl = h.create_component_highlight_group({bg = bg, fg = fg}, devhl)
-        return (isSelected and '%#'..hl..'#' or '') .. dev .. (isSelected and '%#TabLineSel#' or '') .. ' '
+        return ((isSelected and hl) and '%#'..hl..'#' or '') .. dev .. (isSelected and '%#TabLineSel#' or '') .. ' '
     end
     return ''
 end


### PR DESCRIPTION
This fixes the error that appears when using luatab.nvim with the colour scheme https://github.com/cormacrelf/vim-colors-github.

```
E5108: Error executing lua /Users/rstacruz/.vim/vendor/luatab.nvim/lua/luatab/init.lua:52: 
attempt to concatenate local 'hl' (a nil value)
```

![image](https://user-images.githubusercontent.com/74385/136316251-824bc82e-8f2e-4a3f-a08c-5c858765fa80.png)
