### PR TITLE
Allow passing nil as opts in setup()

### DIFF
--- a/lua/luatab/init.lua
+++ b/lua/luatab/init.lua
@@ -101,6 +101,7 @@ M.tabline = function()
 end
 
 local setup = function(opts)
+    opts = opts or {}
     if opts.title then M.title = opts.title end
     if opts.modified then M.modified = opts.modified end
     if opts.windowCount then M.windowCount = opts.windowCount end


### PR DESCRIPTION
This makes `require('luatab').setup()` and `require('luatab').setup{}` behave the same.