### PR TITLE
Adding custom labels for tabs

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,11 @@ Add this to your init.lua:
 require('luatab').setup{}
 ```
 
+Rename the current tab using:
+```
+:LuatabLabelRename
+```
+
 ## Configuration
 
 The plugin calls the `helpers.tabline` function to render the line. It uses the other functions defined in `helpers`, such as `cell,separator,devicon`.


### PR DESCRIPTION
Hi! Thanks for creating such a simple but yet useful plugin for tab management. I know that we may custom the plugin with our own functions, but I think having this custom labels feature may be useful in the core plugin.

## Problem
There are times when I have layouts in tabs referring to some group of buffers, but I forgot the purpose of the group itself because the current file is not descriptive enough. For example, in a tab I have a layout with 3 handlers I'm modifying, but the filename is `index.py`, so when I see that in the tabs, it's hard to remember what this index was for.

## Solution
Having custom labels for specific tabs works, because you can set a name for each tab so instead of looking at the name `index.py` with the nice python icon, you will now see `handlers` with a 🌝 icon (We can change this, or add it to the setup config params as well).

In the case that the custom tab has not been set (i.e. set to "default") the normal plugin behavior is expected, and no changes would be visible.

## Caveats

We can catch the `TabCreate` and `TabClose` events from nvim, and edit the labels table accordingly, but I have not found an easy way to detect whenever a user moves a tab position. This causes that when you move a tab, the custom label would be sticked to the last position. We can create another custom command such as `LuatabLabelReset` to set the custom label to `default` again, and then the user would need to go to the next tab and set the custom label again with `LuatabLabelRenam`.

I'm happy to keep working on this if you think it's valuable, but first I would love to hear your thoughts about this. Thank you!