### PR TITLE
Exclude popup windows from window count

### DIFF
--- a/lua/luatab/init.lua
+++ b/lua/luatab/init.lua
@@ -35,7 +35,10 @@ M.windowCount = function(index)
     local nwins = 0
     local success, wins = pcall(vim.api.nvim_tabpage_list_wins, index)
     if success then
-        for _ in pairs(wins) do nwins = nwins + 1 end
+        local filtered = vim.tbl_filter(function(win)
+            return vim.fn.win_gettype(win) ~= 'popup'
+        end, wins)
+        nwins = #filtered
     end
     return nwins > 1 and '(' .. nwins .. ') ' or ''
 end


### PR DESCRIPTION
Having the window count constantly changing because of cmp completion menu, notification, telescope, etc. is annoying. By filtering popup windows, the count only change when opening or creating another file in a new window.

Maybe there are counterexample where you would want to keep the popup window in the count, but it seems to work well for me.
This could also be easily parametrized via an option in the setup function.

You could also filter on buftype or filetype to gain even more control.